### PR TITLE
Fix segmentation fault on invalid messages

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -3746,13 +3746,14 @@ static int get_difference_on_answer (struct tgl_state *TLS, struct query *q, voi
     }
 
     for (i = 0; i < ml_pos; i++) {
+      // Ignore invalid messages, would cause a null ptr deref otherwise
+      if (ML[i] == NULL) continue;
       bl_do_msg_update (TLS, &ML[i]->permanent_id);
     }
     for (i = 0; i < el_pos; i++) {
       // messages to secret chats that no longer exist are not initialized and NULL
-      if (EL[i]) {
-        bl_do_msg_update (TLS, &EL[i]->permanent_id);
-      }
+      if (EL[i] == NULL) continue;
+      bl_do_msg_update (TLS, &EL[i]->permanent_id);
     }
 
     tfree (ML, ml_pos * sizeof (void *));


### PR DESCRIPTION
`tglf_fetch_alloc_message` can return `NULL` for invalid messages (eg. unknown fwd_id). `bl_do_msg_update` expects a pointer argument, and will crash with a segfault if NULL is used.

This commit introduces a simple check before calling `bl_do_msg_update`.